### PR TITLE
array_key_last: faster implementation

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -26,6 +26,6 @@ if (PHP_VERSION_ID < 70300) {
     }
 
     if (!function_exists('array_key_last')) {
-        function array_key_last(array $array) { $key = null; foreach ($array as $key => $value); return $key; }
+        function array_key_last(array $array) { end($array); return key($array); }
     }
 }


### PR DESCRIPTION
Hello
if I right measured, here is faster implementation for function array_key_last.

I move internal pointer of array.

Benchmark is [on my gist](https://gist.github.com/h4kuna/6353ce99bd45b9c5fcdf49ef6d0e3da8). 

Results on my machine.

```
array_key_first_symfony
0.0096850395202637

array_key_first
0.057085990905762

array_key_last_symfony
0.1387140750885

array_key_last
0.055586814880371
```

