### PR TITLE
Drop "min-stability" tag from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,6 @@
         "files": [ "bootstrap.php" ],
         "classmap": [ "Resources/stubs" ]
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "1.11-dev"


### PR DESCRIPTION
This package is fully stable, as is PHP7.3 so there is no reason to flag it as `dev`.

We should also tag a new release, which will allow people with `min-stability= stable` to also install this package. (For example this blocks `symfony/console` from being installed.)